### PR TITLE
update RADME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ Provide your own cert files and store them into:
 or generate them over a script:
 
 ```sh
-$cd certs
-$. ../scripts/create_cert.sh
+cd certs
+../scripts/create_cert.sh
 ```
 
 ## Basic configs for docker
@@ -177,34 +177,34 @@ BUMPER_ANNOUNCE_IP=0.0.0.0 # replace with the server public ip
 > create with virtual env and run python project local
 
 ```sh
-$python3 -m pip install virtualenv --break-system-packages
-$python3 -m venv venv
-$source ./venv/bin/activate
-$python3 -m pip install .
+python3 -m pip install virtualenv --break-system-packages
+python3 -m venv venv
+source ./venv/bin/activate
+python3 -m pip install .
 
-$python3 -m bumper
+python3 -m bumper
 ```
 
 ### Code quality check
 
 ```sh
-$python3 -m pip install virtualenv --break-system-packages
-$python3 -m venv venv
-$source ./venv/bin/activate
-$python3 -m pip install -e .
-$python3 -m pip install -e .[dev]
+python3 -m pip install virtualenv --break-system-packages
+python3 -m venv venv
+source ./venv/bin/activate
+python3 -m pip install -e .
+python3 -m pip install -e .[dev]
 
-$clear && pre-commit run --all-files
-$clear && pytest
+clear && pre-commit run --all-files
+clear && pytest
 ```
 
 or
 
 ```sh
-$docker-compose -f dev.docker-compose.yaml build
-$docker-compose -f dev.docker-compose.yaml run bumper
+docker-compose -f docker-compose.yaml build
+docker-compose -f docker-compose.yaml run bumper
 
-$clear && pytest
+clear && pytest
 ```
 
 ---


### PR DESCRIPTION
Refactor README.md for command clarity and Docker usage

- Remove leading dollar signs from shell commands for better usability and to clarify that commands do not require root access.
- Update Docker compose commands to use the standardized `docker-compose.yaml` filename, aligning with common Docker practices.

This change aims to simplify the setup instructions for users, making it easier to follow along without confusion over command execution permissions and ensuring consistency in Docker-related documentation.

# Description

This PR introduces two main changes to the README.md file: it simplifies the command syntax by removing the dollar signs ($), and it corrects the Docker compose instructions to reference the correct file name. The adjustment to Docker instructions is particularly important as the `dev.docker-compose.yam`l file does not exist in the repository, leading to potential confusion for users trying to follow the setup steps.

- Command Syntax Simplification: Removed the `$`signs from the beginning of command line instructions to facilitate easier copying and pasting. 

- Docker Compose Instructions Update: Replaced references to a non-existent `dev.docker-compose.yaml` file with the correct `docker-compose.yaml` file that is present in the repository. This ensures the instructions are accurate and executable as intended.

# How Has This Been Tested?

Verified that all commands run as expected without the `$` prefix.
Confirmed that the Docker environment sets up correctly using the `docker-compose.yaml` file, ensuring the application builds and runs as intended.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
