### PR TITLE
chore(release): bump version 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
   "server",
 ]
 
-version = "0.2.1-rc1"
+version = "0.2.1"
 requires-python = ">=3.13.0"
 readme = "README.md"
 license = { text = "GPL-3.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "bumper"
-version = "0.2.1rc1"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## What's Changed

### ✨ Features
- Add ca-certificates download endpoint (#115) (b4b0756) @edenhaus @mvladislav

### 🐛 Fixes
- update dependency cryptography to v46 (67ad754)

### 🔧 Chores
- disable docker release on main branch and update setup-python version (e5b9590)
- update pre-commit and renovate rules (#113) (36f0259)
- update pre-commit hook astral-sh/ruff-pre-commit to v0.13.2 (e476ee7)
- pin dependency python to 3.13.7 (6381b06)
- lock file maintenance (81481ad)
- 🚀 Lock file maintenance Python dependencies (d2dbe20)

### 📝 Documentation
- Add additional workarounds as note for unpinning bot (b462049)
- Update docs/internals/certificate-unpinning-bot.md (86d1ab1)
- Update docs/internals/certificate-unpinning-bot.md (556c593)

### 📦 Other
- Typo (10a385a)
- Fix pre-commit (8962926)