### PR TITLE
chore(release): bump version 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
   "server",
 ]
 
-version = "0.2.2-rc1"
+version = "0.2.2"
 requires-python = ">=3.13.0"
 readme = "README.md"
 license = { text = "GPL-3.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ wheels = [
 
 [[package]]
 name = "bumper"
-version = "0.2.2rc1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION
## What's Changed

### 🐛 Fixes

- rename 'QueryInstance' to 'query_instance' to conform to naming conventions (8d6421e) - by @MVladislav

#### deps

- update dependency aiofiles to v25 (88ecb56) - by @renovate[bot]
- lock file maintenance python dependencies (87564ca) - by @renovate[bot]
- lock file maintenance python dependencies (fe7614d) - by @renovate[bot]
- lock file maintenance python dependencies (2921e9d) - by @renovate[bot]

### 🔧 Chores

- update pre-commit, docker-compose, and CI tooling (prek) (ea52c4c) (#137) - by @MVladislav
  - Pre-commit updates
    - Replace unmaintained `pre-commit/mirrors-prettier` with `rbubley/mirrors-prettier`.
    - Update to the latest Prettier version (affects markdown tabbing in docs).
    - Remove `prettier-plugin-sort-json` - not needed and not quick to add.
    - Replace `dockerfilelint-precommit-hooks` with `hadolint`.
  - `.gitignore` improvements
    - Minor cleanup.
  - Docker-compose enhancements
    - Replace static ports with environment variables.
    - Add `healthcheck` definitions to key services for improved orchestration.
  - Prek and CI integration
    - Replace `pre-commit` tooling with `prek`.
    - Add a `Run prek` step in the CI workflow to enforce code style checks.

#### api

- improve mapping update script and sync sources from origin (7309dc3) (#128) - by @MVladislav

#### deps

- update github actions (f1fb43f) - by @renovate[bot]
- update pre-commit hooks (f193f26) - by @renovate[bot]
- update dependency python to v3.14.0 (1914b54) - by @renovate[bot]
- update python docker tag to v3.14.0 (a3f02b8) - by @renovate[bot]
- update python docker tag to v3.14 (bfdfcdc) - by @renovate[bot]
- extend CI with Python 3.14, update Docker Python & UV, remove .python-version (350d5a8) (#127) - by @MVladislav
- update pre-commit hook astral-sh/ruff-pre-commit to v0.14.1 (cea616e) - by @renovate[bot]
- update pre-commit hook astral-sh/ruff-pre-commit to v0.14.2 (b8dcf15) - by @renovate[bot]
- update actions/upload-artifact action to v5 (433fe4b) - by @renovate[bot]
- lock file maintenance (27b4a8c) - by @renovate[bot]
- update pre-commit hook astral-sh/ruff-pre-commit to v0.14.3 (4ec93a3) - by @renovate[bot]
- update pre-commit hook hadolint/hadolint to v2.14.0 (532609e) - by @renovate[bot]