### PR TITLE
docs: add port 443 redirect and Linux setcap notes

### DIFF
--- a/docs/getting_started/dns.md
+++ b/docs/getting_started/dns.md
@@ -160,6 +160,56 @@ Most domains follow patterns based on country or region codes:
 
 ---
 
+## 🔀 Port Redirect for Newer Robots (jmq-ngiot on port 443)
+
+Some newer robots (confirmed: **Deebot OZMO 920 series**) do **not** connect to Bumper
+on the standard MQTT port (8883). Instead, they connect on **port 443** using the
+`jmq-ngiot-{region}.area.ww.ecouser.net` hostname — likely to traverse firewalls that
+block non-standard ports.
+
+Because Bumper's MQTT broker listens on port 8883, these connections must be redirected
+with an `iptables` rule. The existing DNS wildcard and certificate SANs already cover
+this hostname — it is purely a port interception issue.
+
+**Add the redirect rule** (replace `<BOT_IP>` with your robot's local IP):
+
+```bash
+sudo iptables -t nat -A PREROUTING -s <BOT_IP> -p tcp --dport 443 -j REDIRECT --to-port 8883
+```
+
+**Remove the rule** (e.g. to restore normal cloud access):
+
+```bash
+sudo iptables -t nat -D PREROUTING -s <BOT_IP> -p tcp --dport 443 -j REDIRECT --to-port 8883
+```
+
+> **Note:** This rule is lost on reboot. To persist it, use `iptables-persistent`:
+> ```bash
+> sudo apt install iptables-persistent
+> sudo netfilter-persistent save
+> ```
+
+### How to find your robot's IP
+
+Check your router's DHCP client list, or run:
+
+```bash
+sudo arp-scan --localnet
+```
+
+### How to tell if your robot needs this redirect
+
+After DNS redirection is in place, power-cycle the robot and monitor traffic:
+
+```bash
+sudo tcpdump -i any -n "src host <BOT_IP> and (port 443 or port 8883)"
+```
+
+If you see connections on port **443** with no activity on port **8883**, your robot
+needs this redirect rule.
+
+---
+
 ## 🔍 Troubleshooting
 
 - **App won’t connect**: Test overrides with `dig` or `nslookup` against your DNS server.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -14,3 +14,36 @@ options:
   --debug_level DEBUG_LEVEL     Set debug log level (default: "INFO")
   --debug_verbose DEBUG_VERBOSE Enable verbose debug logs (default: 1)
 ```
+
+---
+
+## ⚠️ Linux: Binding Port 443 Without Root (non-Docker)
+
+Bumper's HTTPS web server binds to port **443** by default. On Linux, ports below 1024
+require either root privileges or the `CAP_NET_BIND_SERVICE` capability.
+
+When running Bumper directly (not via Docker, which handles this through port mapping),
+you must grant that capability to the Python binary used by uv:
+
+```bash
+sudo setcap cap_net_bind_service=+ep \
+  $(readlink -f $(which python3))
+```
+
+Or, if you installed Python via uv:
+
+```bash
+sudo setcap cap_net_bind_service=+ep \
+  ~/.local/share/uv/python/cpython-3.13.*/linux-x86_64-gnu/bin/python3.13
+```
+
+> **Note:** This must be re-applied if uv installs a new Python patch release
+> (e.g. `3.13.12` → `3.13.13`), since the binary path changes.
+
+**Alternative:** Change the HTTPS port to something above 1024 via the
+`WEB_SERVER_HTTPS_PORT` environment variable (see
+[Environment Variables](../configuration/environment.md)):
+
+```bash
+WEB_SERVER_HTTPS_PORT=8443 uv run bumper --listen <YOUR_IP>
+```


### PR DESCRIPTION
## What this adds

**1. Port 443 redirect for newer robots (jmq-ngiot protocol)**

Some newer robots (confirmed: Deebot OZMO 920 series) do not connect on the standard MQTT port (8883). Instead they connect on **port 443** using the `jmq-ngiot-{region}.area.ww.ecouser.net` hostname. Without an iptables redirect, Bumper never receives the connection and the bot silently stays on the cloud.

Diagnosis: `tcpdump` showed the bot connecting on 443 after DNS redirection was in place, with no activity on 8883.

Fix: one iptables PREROUTING REDIRECT rule targeting the bot IP. The cert SANs (`*.area.ww.ecouser.net`) and DNS wildcard already cover this hostname — it is purely a port interception issue.

Added to `docs/getting_started/dns.md`: iptables add/remove commands, tcpdump diagnosis, `iptables-persistent` persistence note.

**2. Linux port 443 binding without root (non-Docker)**

When running Bumper directly (not via Docker), Python cannot bind port 443 without `CAP_NET_BIND_SERVICE`. Added to `docs/usage/cli.md`: `setcap` commands for system Python and uv-managed Python, plus the `WEB_SERVER_HTTPS_PORT` alternative.

## Testing

- Robot: Deebot OZMO 920 series (`vi829v`)
- Protocol: MQTT
- App: Ecovacs Home
- Result: working after applying both fixes above