### PR TITLE
fix(auth): correct JWT expiry and add login2 route

### DIFF
--- a/bumper/web/auth_service.py
+++ b/bumper/web/auth_service.py
@@ -420,7 +420,7 @@ async def generate_jwt_helper(
     payload = {
         "t": t,
         "iat": int(now_dt.timestamp()),
-        "exp": int(exp_dt.timestamp()) if t != "a" else int(now_dt.timestamp()),
+        "exp": int(exp_dt.timestamp()),
     }
     if data:
         payload.update(data)

--- a/bumper/web/plugins/v2/private/user.py
+++ b/bumper/web/plugins/v2/private/user.py
@@ -20,6 +20,7 @@ class UserPlugin(WebserverPlugin):
         """Plugin routes."""
         return [
             web.route("*", f"{BASE_URL}user/login", auth_service.login),
+            web.route("*", f"{BASE_URL}user/login2", auth_service.login),
             web.route("*", f"{BASE_URL}user/checkLogin", auth_service.login),
             web.route("*", f"{BASE_URL}user/checkAgreementBatch", handle_check_agreement_batch),
         ]


### PR DESCRIPTION
# Description

- Adds /login2 endpoint required by the Ecovacs app v3.14+ which switched away from the original login route for some reason. v3.14 is the latest version, but I presume this is the case for any v3.x
- Access tokens were issued with `exp` equal to `iat`, so they expired immediately on creation. Tokens now use the configured validity window. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test Configuration**:

- Firmware version: 1.22.0
- Hardware: Deebot Omni T20
- Toolchain: N/A
- SDK: N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
