### PR TITLE
feat(pim): serve product info from config data

### DIFF
--- a/bumper/web/plugins/api/appsvr.py
+++ b/bumper/web/plugins/api/appsvr.py
@@ -495,7 +495,7 @@ def _include_product_iot_map_info(bot: VacBotDevice) -> dict[str, Any] | None:
                 result["scode"].update(
                     {
                         "tmallstand": True,
-                        "video": True,
+                        "video": botprod_invent.get("video", True),
                         "clean": True,
                         "charge": True,
                         "chargestate": True,

--- a/bumper/web/plugins/api/pim/product.py
+++ b/bumper/web/plugins/api/pim/product.py
@@ -21,6 +21,7 @@ from bumper.web.static_api import (
     get_config_net_all_response,
     get_product_config_batch,
     get_product_entry_group,
+    get_product_info_by_mids,
     get_product_iot_map,
 )
 from bumper.web.utils.response_helper import response_success_v3, response_success_v4
@@ -42,6 +43,7 @@ class ProductPlugin(WebserverPlugin):
             web.route("POST", "/product/getShareInfo", _handle_get_share_info),
             web.route("GET", "/product/image", _get_bot_image),
             web.route("GET", "/product/entry/group", _get_entry_group),
+            web.route("GET", "/product/info", _handle_product_info),
         ]
 
 
@@ -127,3 +129,19 @@ async def _get_bot_image(_: Request) -> FileResponse:
 async def _get_entry_group(_: Request) -> Response:
     """Get entry group."""
     return response_success_v3(data=get_product_entry_group())
+
+
+async def _handle_product_info(request: Request) -> Response:
+    """Get product info for the requested mids.
+
+    Served locally so the request is not proxied upstream (the real cloud rejects
+    bumper-minted credentials). Synthesized generically per-mid from the config
+    groups data, so any known device works, not just a hardcoded subset.
+    """
+    try:
+        mids_param = request.query.get("mids", "")
+        mids = [mid for mid in (m.strip() for m in mids_param.split(",")) if mid]
+        return response_success_v4(get_product_info_by_mids(mids))
+    except Exception:
+        _LOGGER.exception(utils.default_exception_str_builder(info="during handling request"))
+    raise HTTPInternalServerError

--- a/bumper/web/static_api/__init__.py
+++ b/bumper/web/static_api/__init__.py
@@ -1,5 +1,6 @@
 """Api pim module plugin."""
 
+from collections.abc import Iterable
 from functools import cache
 import logging
 from pathlib import Path
@@ -53,9 +54,76 @@ def get_product_iot_map() -> list[dict[str, Any]]:
 
 
 @cache
-def get_product_entry_group() -> dict[str, Any]:
+def get_product_entry_group() -> list[dict[str, Any]]:
     """Get product entry group."""
-    return load_json_object_files("productEntryGroup.json", get_static_dir())
+    return load_json_array_files(["productEntryGroup.json"], get_static_dir())
+
+
+@cache
+def _get_config_groups_by_mid() -> dict[str, dict[str, Any]]:
+    """Build a mid -> robot config lookup from the config groups response.
+
+    The config groups response is a list of families, each with a ``robots`` list.
+    Flatten it into a single mid-keyed dict so per-device lookups (e.g. for
+    ``/product/info``) are O(1). Later duplicate mids win (unofficial overrides).
+    """
+    lookup: dict[str, dict[str, Any]] = {}
+    for family in get_config_groups_response():
+        for robot in family.get("robots", []):
+            mid = robot.get("mid")
+            if mid:
+                lookup[mid] = robot
+    return lookup
+
+
+def _robot_to_product_info(robot: dict[str, Any]) -> dict[str, Any]:
+    """Transform a config-groups robot entry into a ``/product/info`` object.
+
+    The two endpoints serve the same underlying product data but with different
+    envelopes: config groups exposes flat ``steps``/``qrpStep``/``cusSteps`` while
+    ``/product/info`` nests them under ``configNetSteps``. Only the fields the
+    wizard actually reads (mid, status, smartType, groupName) are guaranteed; the
+    rest mirror the real cloud response for a faithful guide UX.
+    """
+    steps = robot.get("steps") or []
+    config_net_steps: dict[str, Any] = {
+        "qrpStep": robot.get("qrpStep", {}),
+        "cusSteps": robot.get("cusSteps", {}),
+    }
+    for index, step in enumerate(steps, start=1):
+        config_net_steps[f"step{index}"] = step
+
+    group_name = robot.get("groupName", "")
+    return {
+        "id": robot.get("groupId", ""),
+        "name": group_name,
+        "groupName": group_name,
+        "mid": robot.get("mid", ""),
+        "smartType": robot.get("smartType", ""),
+        "status": robot.get("status", "valid") or "valid",
+        "snCfgNet": False,
+        "materialNo": robot.get("materialNo", ""),
+        "icon": robot.get("icon", ""),
+        "failCount": robot.get("failCount", 0),
+        "belongApp": robot.get("belongApp", []),
+        "supportType": {"share": True},
+        "configNetSteps": config_net_steps,
+    }
+
+
+def get_product_info_by_mids(mids: Iterable[str]) -> list[dict[str, Any]]:
+    """Get ``/product/info`` objects for the given mids.
+
+    Synthesized generically from the config groups data so any known device mid
+    works, not just a hardcoded subset. Unknown mids are skipped (the real cloud
+    likewise returns only resolvable entries).
+    """
+    lookup = _get_config_groups_by_mid()
+    result: list[dict[str, Any]] = []
+    for mid in mids:
+        if robot := lookup.get(mid):
+            result.append(_robot_to_product_info(robot))
+    return result
 
 
 @cache

--- a/bumper/web/static_api/configNetAllResponse.json
+++ b/bumper/web/static_api/configNetAllResponse.json
@@ -2662,8 +2662,8 @@
     "smartType": "MQ_AP",
     "failCount": 0,
     "checkTips": 0,
-    "materialNo": "",
-    "mid": "",
+    "materialNo": "110-2230-0208",
+    "mid": "p1jij8",
     "ota": false,
     "supportVer": {
       "Android": "2.0.0",

--- a/bumper/web/static_api/productIotMap.json
+++ b/bumper/web/static_api/productIotMap.json
@@ -4132,6 +4132,7 @@
       "model": "DARWIN_OMNI",
       "UILogicId": "t10_ww_n_darwin",
       "ota": true,
+      "video": false,
       "supportType": {
         "share": true
       },


### PR DESCRIPTION
# Description

The app device setup wizard queries `/product/info` for model details. Bumper had no handler, so the wizard stalled. Uses the responses from existing configNetAll and productIotMap data instead of hardcoding per-model entries.

Also fixes stale entries in the static config files.

I'm unsure about the changes in `get_product_entry_group()`. The new app refuses to work properly without that change. Also unsure how best to address it and test it with an older version I guess.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
