### PR TITLE
Don't alter command names

### DIFF
--- a/bumper/mqtt/helper_bot.py
+++ b/bumper/mqtt/helper_bot.py
@@ -69,9 +69,6 @@ class MQTTCommandModel:
         self.td = cmdjson.get("td")
 
         self.cmd_name = cmdjson.get("cmdName")
-        if self.cmd_name == "clean_V2":
-            self.cmd_name = "clean"
-
         payload_j = cmdjson.get("payload")
         self.payload = json.dumps(payload_j) if self.payload_type == "j" else str(payload_j)
 
@@ -97,8 +94,6 @@ class MQTTCommandModel:
             self.cmd_name = self.cmd_name[0].lower() + self.cmd_name[1:] if self.cmd_name else None
         if self.cmd_name == "getBatteryInfo":
             self.cmd_name = "getBattery"
-        # if self.cmd_name == "clean_V2":
-        #     self.cmd_name = "clean"
 
         self.did = cmdjson.get("did")
         self.to_type = cmdjson.get("mid")
@@ -106,7 +101,6 @@ class MQTTCommandModel:
         # self.td = cmdjson.get("")
 
         payload_j: dict[str, Any] | None = cmdjson.get("data")
-        # if payload_j and self.cmd_name in {"clean", "clean_V2"}:
         if payload_j and self.cmd_name == "clean":
             act_translation = {
                 "s": "start",

--- a/tests/mqtt/test_helper_bot.py
+++ b/tests/mqtt/test_helper_bot.py
@@ -26,7 +26,7 @@ def test_mqtt_command_model_version_1() -> None:
     assert cmd.to_type == "ls1ok3"
     assert cmd.to_res == "res_123"
     assert cmd.td == "test_td"
-    assert cmd.cmd_name == "clean"  # clean_V2 -> clean
+    assert cmd.cmd_name == "clean_V2"
     assert cmd.payload == '{"key": "value"}'
     assert cmd.payload_type == "j"
 


### PR DESCRIPTION
# Description

The rename of the command from `clean_V2` to `clean` will break vacuums including my ones: Deebot N20 and Deebot N20 Pro.
The server should just act as bridge and not alter anything. The client should use the correct command.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
