### PR TITLE
chore(release): bump version v0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
   "server",
 ]
 
-version = "0.4.0"
+version = "0.4.1"
 requires-python = ">=3.13.0"
 readme = "README.md"
 license = { text = "GPL-3.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "bumper"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodns" },


### PR DESCRIPTION

> 6 commits - 2 contributors - 6 files changed (+211 −217)

## Highlights

- **Restore goat command names in Home-Assistant**: removed the `clean_V2` → `clean` rewrite in the MQTT helper, so original command names are sent untouched ([#253](https://github.com/MVladislav/bumper/pull/253))
- **Security**: `cryptography` bumped to v50 (security update) ([#259](https://github.com/MVladislav/bumper/pull/259))

## What's Changed

### 🐛 Fixes

- remove 'clean_V2' to 'clean' rewrite in mqtt helper ([`089b60b`](https://github.com/MVladislav/bumper/commit/089b60bf0374bb29fb44c781bf238a347de304b7)) ([#253](https://github.com/MVladislav/bumper/pull/253)) - by @edenhaus

#### deps

- update dependency cryptography to v50 [security] ([`ae57ecc`](https://github.com/MVladislav/bumper/commit/ae57ecc72d91b880f259bdeae99bcd7ee689998c)) ([#259](https://github.com/MVladislav/bumper/pull/259)) - by @renovate[bot]
- update dependency cachetools to v7.1.7 ([`b81760a`](https://github.com/MVladislav/bumper/commit/b81760ab479e718e4675bed40848b376d08e4771)) ([#254](https://github.com/MVladislav/bumper/pull/254)) - by @renovate[bot]

### 🔧 Chores

#### deps

- update pre-commit hook hadolint/hadolint to v2.15.1 ([`ecebc5b`](https://github.com/MVladislav/bumper/commit/ecebc5b299de93466c1d14c9d8a8c431ffc875b6)) ([#251](https://github.com/MVladislav/bumper/pull/251)) - by @renovate[bot]
- update github/codeql-action action to v4.37.5 ([`90bdf2e`](https://github.com/MVladislav/bumper/commit/90bdf2ee76f352f1ce8114d4c0d6c5521b29941c)) ([#257](https://github.com/MVladislav/bumper/pull/257)) - by @renovate[bot]
- lock file maintenance ([`e189968`](https://github.com/MVladislav/bumper/commit/e1899681df8bcb2807e64b86d6385aca805c0365)) ([#256](https://github.com/MVladislav/bumper/pull/256)) - by @renovate[bot]

**Full Changelog**: https://github.com/MVladislav/bumper/compare/v0.4.0...v0.4.1